### PR TITLE
Create Manage Tags Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .vscode/
+*.code-workspace
+.prettierrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -6772,9 +6772,9 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/react-router-dom": "^5.1.7",
     "@types/reactstrap": "^8.7.2",
     "circular-dependency-plugin": "^5.2.2",
+    "postcss": "^8.3.6",
     "ts-loader": "^8.0.13",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "typescript": "^4.1.3"

--- a/src/app/SidebarCategories.ts
+++ b/src/app/SidebarCategories.ts
@@ -34,11 +34,11 @@ const admin: SideBarCategory = {
 	children: [
 		usersPageRoute,
 		manageClassInstructorsPageRoute,
+		manageTagsPageRoute,
 	],
 	unrenderedChildren: [
 		usersNewPageRoute,
 		usersEditPageRoute,
-		manageTagsPageRoute,
 	]
 };
 

--- a/src/app/SidebarCategories.ts
+++ b/src/app/SidebarCategories.ts
@@ -1,30 +1,29 @@
+import { Compass, Sliders as SlidersIcon, HelpCircle } from "react-feather";
 import {
-	Compass,
-	Sliders as SlidersIcon,
-	HelpCircle
-} from "react-feather";
-import { usersEditPageRoute, usersNewPageRoute, usersPageRoute } from "./routes/users";
+	usersEditPageRoute,
+	usersNewPageRoute,
+	usersPageRoute,
+} from "./routes/users";
 import RouteWrapper from "../core/RouteWrapper";
 import { jpClassesPageRoute } from "@routes/jp-classes";
 import { staggeredOrderRoute } from "@routes/staggered-order";
 import { manageClassInstructorsPageRoute } from "@routes/admin/class-instructors";
+import { manageTagsPageRoute } from "@routes/admin/tags";
 
 export type SideBarCategory = {
-	path: string,
-	name: string,
-	icon: React.ComponentType,
-	children: RouteWrapper<any>[],
-	unrenderedChildren?: RouteWrapper<any>[],
-}
+	path: string;
+	name: string;
+	icon: React.ComponentType;
+	children: RouteWrapper<any>[];
+	unrenderedChildren?: RouteWrapper<any>[];
+};
 
 const jp: SideBarCategory = {
 	path: "/jp-classes",
 	name: "Junior Program",
 	icon: Compass,
-	children: [
-		jpClassesPageRoute
-	]
-}
+	children: [jpClassesPageRoute],
+};
 
 const admin: SideBarCategory = {
 	path: "/tables",
@@ -33,27 +32,18 @@ const admin: SideBarCategory = {
 	children: [
 		usersPageRoute,
 		manageClassInstructorsPageRoute,
+		manageTagsPageRoute,
 	],
-	unrenderedChildren: [
-		usersNewPageRoute,
-		usersEditPageRoute,
-	]
+	unrenderedChildren: [usersNewPageRoute, usersEditPageRoute],
 };
 
 const misc: SideBarCategory = {
 	path: "",
 	name: "Misc",
 	icon: HelpCircle,
-	children: [
-	],
-	unrenderedChildren: [
-		staggeredOrderRoute
-	]
+	children: [],
+	unrenderedChildren: [staggeredOrderRoute],
 };
 
 // Dashboard specific routes
-export const sideBarRoutes = [
-	jp,
-	admin,
-	misc,
-];
+export const sideBarRoutes = [jp, admin, misc];

--- a/src/app/SidebarCategories.ts
+++ b/src/app/SidebarCategories.ts
@@ -1,9 +1,9 @@
-import { Compass, Sliders as SlidersIcon, HelpCircle } from "react-feather";
 import {
-	usersEditPageRoute,
-	usersNewPageRoute,
-	usersPageRoute,
-} from "./routes/users";
+	Compass,
+	Sliders as SlidersIcon,
+	HelpCircle
+} from "react-feather";
+import { usersEditPageRoute, usersNewPageRoute, usersPageRoute } from "./routes/users";
 import RouteWrapper from "../core/RouteWrapper";
 import { jpClassesPageRoute } from "@routes/jp-classes";
 import { staggeredOrderRoute } from "@routes/staggered-order";
@@ -11,19 +11,21 @@ import { manageClassInstructorsPageRoute } from "@routes/admin/class-instructors
 import { manageTagsPageRoute } from "@routes/admin/tags";
 
 export type SideBarCategory = {
-	path: string;
-	name: string;
-	icon: React.ComponentType;
-	children: RouteWrapper<any>[];
-	unrenderedChildren?: RouteWrapper<any>[];
-};
+	path: string,
+	name: string,
+	icon: React.ComponentType,
+	children: RouteWrapper<any>[],
+	unrenderedChildren?: RouteWrapper<any>[],
+}
 
 const jp: SideBarCategory = {
 	path: "/jp-classes",
 	name: "Junior Program",
 	icon: Compass,
-	children: [jpClassesPageRoute],
-};
+	children: [
+		jpClassesPageRoute
+	]
+}
 
 const admin: SideBarCategory = {
 	path: "/tables",
@@ -32,18 +34,28 @@ const admin: SideBarCategory = {
 	children: [
 		usersPageRoute,
 		manageClassInstructorsPageRoute,
-		manageTagsPageRoute,
 	],
-	unrenderedChildren: [usersNewPageRoute, usersEditPageRoute],
+	unrenderedChildren: [
+		usersNewPageRoute,
+		usersEditPageRoute,
+		manageTagsPageRoute,
+	]
 };
 
 const misc: SideBarCategory = {
 	path: "",
 	name: "Misc",
 	icon: HelpCircle,
-	children: [],
-	unrenderedChildren: [staggeredOrderRoute],
+	children: [
+	],
+	unrenderedChildren: [
+		staggeredOrderRoute
+	]
 };
 
 // Dashboard specific routes
-export const sideBarRoutes = [jp, admin, misc];
+export const sideBarRoutes = [
+	jp,
+	admin,
+	misc,
+];

--- a/src/app/routes/admin/tags.tsx
+++ b/src/app/routes/admin/tags.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import * as t from "io-ts";
+
+import RouteWrapper from "@core/RouteWrapper";
+import PageWrapper from "@core/PageWrapper";
+import Loader from "@components/Loader";
+
+import { adminBasePath } from "./_base";
+import { PageName } from "pages/pageNames";
+import ManageTagsPage from "pages/admin/ManageTagsPage";
+import { validator, getWrapper } from "@async/rest/tags";
+
+export const manageTagsPath = adminBasePath.appendPathSegment("tags");
+
+export const manageTagsPageRoute = new RouteWrapper(
+    {
+        requiresAuth: true,
+        exact: true,
+        pathWrapper: manageTagsPath,
+        sidebarTitle: "Manage Tags",
+        pageName: PageName.MANAGE_TAGS,
+        requireSudo: true,
+    },
+    (history) => (
+        <PageWrapper
+            key="manage tags"
+            history={history}
+            component={(_urlProps: {}, async: t.TypeOf<typeof validator>) => (
+                <ManageTagsPage tags={async} />
+            )}
+            urlProps={{}}
+            getAsyncProps={() => {
+                return getWrapper.send(null);
+            }}
+            shadowComponent={<Loader />}
+        />
+    )
+);

--- a/src/app/routes/admin/tags.tsx
+++ b/src/app/routes/admin/tags.tsx
@@ -13,26 +13,26 @@ import { validator, getWrapper } from "@async/rest/tags";
 export const manageTagsPath = adminBasePath.appendPathSegment("tags");
 
 export const manageTagsPageRoute = new RouteWrapper(
-    {
-        requiresAuth: true,
-        exact: true,
-        pathWrapper: manageTagsPath,
-        sidebarTitle: "Manage Tags",
-        pageName: PageName.MANAGE_TAGS,
-        requireSudo: true,
-    },
-    (history) => (
-        <PageWrapper
-            key="manage tags"
-            history={history}
-            component={(_urlProps: {}, async: t.TypeOf<typeof validator>) => (
-                <ManageTagsPage tags={async} />
-            )}
-            urlProps={{}}
-            getAsyncProps={() => {
-                return getWrapper.send(null);
-            }}
-            shadowComponent={<Loader />}
-        />
-    )
+	{
+		requiresAuth: true,
+		exact: true,
+		pathWrapper: manageTagsPath,
+		sidebarTitle: "Manage Tags",
+		pageName: PageName.MANAGE_TAGS,
+		requireSudo: true,
+	},
+	(history) => (
+		<PageWrapper
+			key="manage tags"
+			history={history}
+			component={(_urlProps: {}, async: t.TypeOf<typeof validator>) => (
+				<ManageTagsPage tags={async} />
+			)}
+			urlProps={{}}
+			getAsyncProps={() => {
+				return getWrapper.send(null);
+			}}
+			shadowComponent={<Loader />}
+		/>
+	)
 );

--- a/src/async/rest/tags.ts
+++ b/src/async/rest/tags.ts
@@ -1,0 +1,32 @@
+import * as t from "io-ts";
+import APIWrapper from "../../core/APIWrapper";
+import { HttpMethod } from "../../core/HttpMethod";
+
+export const tagValidator = t.type({
+    TAG_ID: t.number,
+    TAG_NAME: t.string,
+});
+
+export const validator = t.array(tagValidator);
+
+const path = "/rest/tag";
+
+export const getWrapper = new APIWrapper({
+    path,
+    type: HttpMethod.GET,
+    resultValidator: validator,
+});
+
+const resultValidator = t.type({
+    TAG_ID: t.number,
+});
+
+export const putWrapper = new APIWrapper<
+    typeof resultValidator,
+    t.TypeOf<typeof tagValidator>,
+    null
+>({
+    path,
+    type: HttpMethod.POST,
+    resultValidator,
+});

--- a/src/async/rest/tags.ts
+++ b/src/async/rest/tags.ts
@@ -3,8 +3,8 @@ import APIWrapper from "../../core/APIWrapper";
 import { HttpMethod } from "../../core/HttpMethod";
 
 export const tagValidator = t.type({
-    TAG_ID: t.number,
-    TAG_NAME: t.string,
+	TAG_ID: t.number,
+	TAG_NAME: t.string,
 });
 
 export const validator = t.array(tagValidator);
@@ -12,21 +12,21 @@ export const validator = t.array(tagValidator);
 const path = "/rest/tag";
 
 export const getWrapper = new APIWrapper({
-    path,
-    type: HttpMethod.GET,
-    resultValidator: validator,
+	path,
+	type: HttpMethod.GET,
+	resultValidator: validator,
 });
 
 const resultValidator = t.type({
-    TAG_ID: t.number,
+	TAG_ID: t.number,
 });
 
 export const putWrapper = new APIWrapper<
-    typeof resultValidator,
-    t.TypeOf<typeof tagValidator>,
-    null
+	typeof resultValidator,
+	t.TypeOf<typeof tagValidator>,
+	null
 >({
-    path,
-    type: HttpMethod.POST,
-    resultValidator,
+	path,
+	type: HttpMethod.POST,
+	resultValidator,
 });

--- a/src/components/ReportWithModalForm.tsx
+++ b/src/components/ReportWithModalForm.tsx
@@ -1,137 +1,193 @@
 import * as React from "react";
-import * as t from 'io-ts';
-import { Card, CardHeader, CardTitle, CardBody, Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
-import { ColumnDescription } from "react-bootstrap-table-next";
+import * as t from "io-ts";
 import {
-	Edit as EditIcon,
-} from 'react-feather'
+    Card,
+    CardHeader,
+    CardTitle,
+    CardBody,
+    Modal,
+    ModalHeader,
+    ModalBody,
+    ModalFooter,
+    Button,
+} from "reactstrap";
+import { ColumnDescription } from "react-bootstrap-table-next";
+import { Edit as EditIcon } from "react-feather";
 import { SimpleReport } from "@core/SimpleReport";
 import { ErrorPopup } from "@components/ErrorPopup";
 import { none, Option, some } from "fp-ts/lib/Option";
 import { makePostJSON } from "@core/APIWrapperUtil";
 import APIWrapper from "@core/APIWrapper";
-import { deoptionifyProps, OptionifiedProps, optionifyAndMakeDefault, optionifyProps } from "@util/OptionifyObjectProps";
+import {
+    deoptionifyProps,
+    OptionifiedProps,
+    optionifyAndMakeDefault,
+    optionifyProps,
+} from "@util/OptionifyObjectProps";
 import { ButtonWrapper } from "./ButtonWrapper";
 
-export default function ReportWithModalForm<T extends t.TypeC<any>, U extends object = t.TypeOf<T>>(props: {
-	rowValidator: T
-	rows: U[],
-	primaryKey: string & keyof U,
-	columns: ColumnDescription[],
-	form: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string) => void) => JSX.Element
-	submitRow: APIWrapper<any, U, any>
+export default function ReportWithModalForm<
+    T extends t.TypeC<any>,
+    U extends object = t.TypeOf<T>
+>(props: {
+    rowValidator: T;
+    rows: U[];
+    primaryKey: string & keyof U;
+    columns: ColumnDescription[];
+    form: (
+        rowForEdit: OptionifiedProps<U>,
+        updateState: (id: string, value: string) => void
+    ) => JSX.Element;
+    submitRow: APIWrapper<any, U, any>;
+    cardTitle?: React.ReactNode;
 }) {
-	const blankForm = {
-		rowForEdit: optionifyAndMakeDefault(props.rowValidator),
-	}
+    const blankForm = {
+        rowForEdit: optionifyAndMakeDefault(props.rowValidator),
+    };
 
-	const [modalIsOpen, setModalIsOpen] = React.useState(false);
-	const [validationErrors, setValidationErrors] = React.useState([] as string[]);
-	const [formData, setFormData] = React.useState(blankForm);
-	const [rowData, updateRowData] = React.useState(props.rows);
+    const [modalIsOpen, setModalIsOpen] = React.useState(false);
+    const [validationErrors, setValidationErrors] = React.useState(
+        [] as string[]
+    );
+    const [formData, setFormData] = React.useState(blankForm);
+    const [rowData, updateRowData] = React.useState(props.rows);
 
-	const openForEdit = (id: Option<string>) => {
-		setModalIsOpen(true);
-		setValidationErrors([]);
-		if (id.isSome()) {
-			const row = rowData.find(i => String(i[props.primaryKey]) == id.getOrElse(null))
-			setFormData({
-				rowForEdit: optionifyProps(row),
-			})
-		} else {
-			setFormData(blankForm)
-		}
-	}
+    const openForEdit = (id: Option<string>) => {
+        setModalIsOpen(true);
+        setValidationErrors([]);
+        if (id.isSome()) {
+            const row = rowData.find(
+                (i) => String(i[props.primaryKey]) == id.getOrElse(null)
+            );
+            setFormData({
+                rowForEdit: optionifyProps(row),
+            });
+        } else {
+            setFormData(blankForm);
+        }
+    };
 
-	const updateState = (id: string, value: string) => {
-		setFormData({
-			...formData,
-			rowForEdit: {
-				...formData.rowForEdit,
-				[id]: some(value)
-			}
-		})
-	}
+    const updateState = (id: string, value: string) => {
+        setFormData({
+            ...formData,
+            rowForEdit: {
+                ...formData.rowForEdit,
+                [id]: some(value),
+            },
+        });
+    };
 
-	function closeModal() {
-		setModalIsOpen(false);
-		setFormData(blankForm);
-	}
+    function closeModal() {
+        setModalIsOpen(false);
+        setFormData(blankForm);
+    }
 
-	const submit = () => {
-		return props.submitRow.send(makePostJSON(deoptionifyProps(formData.rowForEdit))).then(ret => {
-			if (ret.type == "Success") {
-				closeModal();
-				if (rowData.find(r => r[props.primaryKey] == formData.rowForEdit[props.primaryKey].getOrElse(null))) {
-					// was an update
-					updateRowData(rowData.map(row => {
-						if (formData.rowForEdit[props.primaryKey].getOrElse(null) == row[props.primaryKey]) {
-							return deoptionifyProps(formData.rowForEdit);
-						} else return row;
-					}))
-				} else {
-					// was a create
-					updateRowData(rowData.concat([{
-						...deoptionifyProps(formData.rowForEdit),
-						[props.primaryKey]: ret.success[props.primaryKey]
-					}]))
-				}
-			} else {
-				setValidationErrors([ret.message])
-			}
-		})
-	}
+    const submit = () => {
+        return props.submitRow
+            .send(makePostJSON(deoptionifyProps(formData.rowForEdit)))
+            .then((ret) => {
+                if (ret.type == "Success") {
+                    closeModal();
+                    if (
+                        rowData.find(
+                            (r) =>
+                                r[props.primaryKey] ==
+                                formData.rowForEdit[props.primaryKey].getOrElse(
+                                    null
+                                )
+                        )
+                    ) {
+                        // was an update
+                        updateRowData(
+                            rowData.map((row) => {
+                                if (
+                                    formData.rowForEdit[
+                                        props.primaryKey
+                                    ].getOrElse(null) == row[props.primaryKey]
+                                ) {
+                                    return deoptionifyProps(
+                                        formData.rowForEdit
+                                    );
+                                } else return row;
+                            })
+                        );
+                    } else {
+                        // was a create
+                        updateRowData(
+                            rowData.concat([
+                                {
+                                    ...deoptionifyProps(formData.rowForEdit),
+                                    [props.primaryKey]:
+                                        ret.success[props.primaryKey],
+                                },
+                            ])
+                        );
+                    }
+                } else {
+                    setValidationErrors([ret.message]);
+                }
+            });
+    };
 
-	const data = rowData.map(r => ({
-		...r,
-		edit: <a href="" onClick={e => {
-			e.preventDefault();
-			openForEdit(some(String(r[props.primaryKey])));
-		}}><EditIcon color="#777" size="1.4em" /></a>,
-	}));
+    const data = rowData.map((r) => ({
+        ...r,
+        edit: (
+            <a
+                href=""
+                onClick={(e) => {
+                    e.preventDefault();
+                    openForEdit(some(String(r[props.primaryKey])));
+                }}
+            >
+                <EditIcon color="#777" size="1.4em" />
+            </a>
+        ),
+    }));
 
-	console.log(formData)
+    console.log(formData);
 
-	return <React.Fragment>
-		<Modal
-			isOpen={modalIsOpen}
-			toggle={closeModal}
-			centered
-		>
-			<ModalHeader toggle={closeModal}>
-				Add/Edit
-			</ModalHeader>
-			<ModalBody className="text-center m-3">
-				<ErrorPopup errors={validationErrors}/>
-				{props.form(formData.rowForEdit, updateState)}
-			</ModalBody>
-			<ModalFooter>
-				<Button color="secondary" outline onClick={closeModal}>
-					Cancel
-				</Button>{" "}
-				<ButtonWrapper spinnerOnClick onClick={submit} >
-					Save
-				</ButtonWrapper>
-			</ModalFooter>
-		</Modal>
-		<Card>
-			<CardHeader>
-				<CardTitle tag="h5" className="mb-0">JP Class Instructors</CardTitle>
-			</CardHeader>
-			<CardBody>
-				<div style={{width: "900px"}} >
-					<SimpleReport 
-						keyField={props.primaryKey}
-						data={data}
-						columns={props.columns}
-						bootstrap4
-						bordered={false}
-						sizePerPage={12}
-						sizePerPageList={[12, 25, 50, 1000]}
-					/>
-					<Button className="mr-1 mb-1" outline onClick={() => openForEdit(none) }>Add Row</Button>
-				</div>
-			</CardBody>
-		</Card>
-	</React.Fragment>;
+    return (
+        <React.Fragment>
+            <Modal isOpen={modalIsOpen} toggle={closeModal} centered>
+                <ModalHeader toggle={closeModal}>Add/Edit</ModalHeader>
+                <ModalBody className="text-center m-3">
+                    <ErrorPopup errors={validationErrors} />
+                    {props.form(formData.rowForEdit, updateState)}
+                </ModalBody>
+                <ModalFooter>
+                    <Button color="secondary" outline onClick={closeModal}>
+                        Cancel
+                    </Button>{" "}
+                    <ButtonWrapper spinnerOnClick onClick={submit}>
+                        Save
+                    </ButtonWrapper>
+                </ModalFooter>
+            </Modal>
+            <Card>
+                <CardHeader>
+                    <CardTitle tag="h5" className="mb-0">
+                        {props.cardTitle ?? "Report Table"}
+                    </CardTitle>
+                </CardHeader>
+                <CardBody>
+                    <SimpleReport
+                        keyField={props.primaryKey}
+                        data={data}
+                        columns={props.columns}
+                        bootstrap4
+                        bordered={false}
+                        sizePerPage={12}
+                        sizePerPageList={[12, 25, 50, 1000]}
+                    />
+                    <Button
+                        className="mr-1 mb-1"
+                        outline
+                        onClick={() => openForEdit(none)}
+                    >
+                        Add Row
+                    </Button>
+                </CardBody>
+            </Card>
+        </React.Fragment>
+    );
 }

--- a/src/components/ReportWithModalForm.tsx
+++ b/src/components/ReportWithModalForm.tsx
@@ -1,193 +1,138 @@
 import * as React from "react";
-import * as t from "io-ts";
-import {
-    Card,
-    CardHeader,
-    CardTitle,
-    CardBody,
-    Modal,
-    ModalHeader,
-    ModalBody,
-    ModalFooter,
-    Button,
-} from "reactstrap";
+import * as t from 'io-ts';
+import { Card, CardHeader, CardTitle, CardBody, Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { ColumnDescription } from "react-bootstrap-table-next";
-import { Edit as EditIcon } from "react-feather";
+import {
+	Edit as EditIcon,
+} from 'react-feather'
 import { SimpleReport } from "@core/SimpleReport";
 import { ErrorPopup } from "@components/ErrorPopup";
 import { none, Option, some } from "fp-ts/lib/Option";
 import { makePostJSON } from "@core/APIWrapperUtil";
 import APIWrapper from "@core/APIWrapper";
-import {
-    deoptionifyProps,
-    OptionifiedProps,
-    optionifyAndMakeDefault,
-    optionifyProps,
-} from "@util/OptionifyObjectProps";
+import { deoptionifyProps, OptionifiedProps, optionifyAndMakeDefault, optionifyProps } from "@util/OptionifyObjectProps";
 import { ButtonWrapper } from "./ButtonWrapper";
 
-export default function ReportWithModalForm<
-    T extends t.TypeC<any>,
-    U extends object = t.TypeOf<T>
->(props: {
-    rowValidator: T;
-    rows: U[];
-    primaryKey: string & keyof U;
-    columns: ColumnDescription[];
-    form: (
-        rowForEdit: OptionifiedProps<U>,
-        updateState: (id: string, value: string) => void
-    ) => JSX.Element;
-    submitRow: APIWrapper<any, U, any>;
-    cardTitle?: React.ReactNode;
+export default function ReportWithModalForm<T extends t.TypeC<any>, U extends object = t.TypeOf<T>>(props: {
+	rowValidator: T
+	rows: U[],
+	primaryKey: string & keyof U,
+	columns: ColumnDescription[],
+	form: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string) => void) => JSX.Element
+	submitRow: APIWrapper<any, U, any>,
+    cardTitle?: React.ReactNode
 }) {
-    const blankForm = {
-        rowForEdit: optionifyAndMakeDefault(props.rowValidator),
-    };
+	const blankForm = {
+		rowForEdit: optionifyAndMakeDefault(props.rowValidator),
+	}
 
-    const [modalIsOpen, setModalIsOpen] = React.useState(false);
-    const [validationErrors, setValidationErrors] = React.useState(
-        [] as string[]
-    );
-    const [formData, setFormData] = React.useState(blankForm);
-    const [rowData, updateRowData] = React.useState(props.rows);
+	const [modalIsOpen, setModalIsOpen] = React.useState(false);
+	const [validationErrors, setValidationErrors] = React.useState([] as string[]);
+	const [formData, setFormData] = React.useState(blankForm);
+	const [rowData, updateRowData] = React.useState(props.rows);
 
-    const openForEdit = (id: Option<string>) => {
-        setModalIsOpen(true);
-        setValidationErrors([]);
-        if (id.isSome()) {
-            const row = rowData.find(
-                (i) => String(i[props.primaryKey]) == id.getOrElse(null)
-            );
-            setFormData({
-                rowForEdit: optionifyProps(row),
-            });
-        } else {
-            setFormData(blankForm);
-        }
-    };
+	const openForEdit = (id: Option<string>) => {
+		setModalIsOpen(true);
+		setValidationErrors([]);
+		if (id.isSome()) {
+			const row = rowData.find(i => String(i[props.primaryKey]) == id.getOrElse(null))
+			setFormData({
+				rowForEdit: optionifyProps(row),
+			})
+		} else {
+			setFormData(blankForm)
+		}
+	}
 
-    const updateState = (id: string, value: string) => {
-        setFormData({
-            ...formData,
-            rowForEdit: {
-                ...formData.rowForEdit,
-                [id]: some(value),
-            },
-        });
-    };
+	const updateState = (id: string, value: string) => {
+		setFormData({
+			...formData,
+			rowForEdit: {
+				...formData.rowForEdit,
+				[id]: some(value)
+			}
+		})
+	}
 
-    function closeModal() {
-        setModalIsOpen(false);
-        setFormData(blankForm);
-    }
+	function closeModal() {
+		setModalIsOpen(false);
+		setFormData(blankForm);
+	}
 
-    const submit = () => {
-        return props.submitRow
-            .send(makePostJSON(deoptionifyProps(formData.rowForEdit)))
-            .then((ret) => {
-                if (ret.type == "Success") {
-                    closeModal();
-                    if (
-                        rowData.find(
-                            (r) =>
-                                r[props.primaryKey] ==
-                                formData.rowForEdit[props.primaryKey].getOrElse(
-                                    null
-                                )
-                        )
-                    ) {
-                        // was an update
-                        updateRowData(
-                            rowData.map((row) => {
-                                if (
-                                    formData.rowForEdit[
-                                        props.primaryKey
-                                    ].getOrElse(null) == row[props.primaryKey]
-                                ) {
-                                    return deoptionifyProps(
-                                        formData.rowForEdit
-                                    );
-                                } else return row;
-                            })
-                        );
-                    } else {
-                        // was a create
-                        updateRowData(
-                            rowData.concat([
-                                {
-                                    ...deoptionifyProps(formData.rowForEdit),
-                                    [props.primaryKey]:
-                                        ret.success[props.primaryKey],
-                                },
-                            ])
-                        );
-                    }
-                } else {
-                    setValidationErrors([ret.message]);
-                }
-            });
-    };
+	const submit = () => {
+		return props.submitRow.send(makePostJSON(deoptionifyProps(formData.rowForEdit))).then(ret => {
+			if (ret.type == "Success") {
+				closeModal();
+				if (rowData.find(r => r[props.primaryKey] == formData.rowForEdit[props.primaryKey].getOrElse(null))) {
+					// was an update
+					updateRowData(rowData.map(row => {
+						if (formData.rowForEdit[props.primaryKey].getOrElse(null) == row[props.primaryKey]) {
+							return deoptionifyProps(formData.rowForEdit);
+						} else return row;
+					}))
+				} else {
+					// was a create
+					updateRowData(rowData.concat([{
+						...deoptionifyProps(formData.rowForEdit),
+						[props.primaryKey]: ret.success[props.primaryKey]
+					}]))
+				}
+			} else {
+				setValidationErrors([ret.message])
+			}
+		})
+	}
 
-    const data = rowData.map((r) => ({
-        ...r,
-        edit: (
-            <a
-                href=""
-                onClick={(e) => {
-                    e.preventDefault();
-                    openForEdit(some(String(r[props.primaryKey])));
-                }}
-            >
-                <EditIcon color="#777" size="1.4em" />
-            </a>
-        ),
-    }));
+	const data = rowData.map(r => ({
+		...r,
+		edit: <a href="" onClick={e => {
+			e.preventDefault();
+			openForEdit(some(String(r[props.primaryKey])));
+		}}><EditIcon color="#777" size="1.4em" /></a>,
+	}));
 
-    console.log(formData);
+	console.log(formData)
 
-    return (
-        <React.Fragment>
-            <Modal isOpen={modalIsOpen} toggle={closeModal} centered>
-                <ModalHeader toggle={closeModal}>Add/Edit</ModalHeader>
-                <ModalBody className="text-center m-3">
-                    <ErrorPopup errors={validationErrors} />
-                    {props.form(formData.rowForEdit, updateState)}
-                </ModalBody>
-                <ModalFooter>
-                    <Button color="secondary" outline onClick={closeModal}>
-                        Cancel
-                    </Button>{" "}
-                    <ButtonWrapper spinnerOnClick onClick={submit}>
-                        Save
-                    </ButtonWrapper>
-                </ModalFooter>
-            </Modal>
-            <Card>
-                <CardHeader>
-                    <CardTitle tag="h5" className="mb-0">
-                        {props.cardTitle ?? "Report Table"}
-                    </CardTitle>
-                </CardHeader>
-                <CardBody>
-                    <SimpleReport
-                        keyField={props.primaryKey}
-                        data={data}
-                        columns={props.columns}
-                        bootstrap4
-                        bordered={false}
-                        sizePerPage={12}
-                        sizePerPageList={[12, 25, 50, 1000]}
-                    />
-                    <Button
-                        className="mr-1 mb-1"
-                        outline
-                        onClick={() => openForEdit(none)}
-                    >
-                        Add Row
-                    </Button>
-                </CardBody>
-            </Card>
-        </React.Fragment>
-    );
+	return <React.Fragment>
+		<Modal
+			isOpen={modalIsOpen}
+			toggle={closeModal}
+			centered
+		>
+			<ModalHeader toggle={closeModal}>
+				Add/Edit
+			</ModalHeader>
+			<ModalBody className="text-center m-3">
+				<ErrorPopup errors={validationErrors}/>
+				{props.form(formData.rowForEdit, updateState)}
+			</ModalBody>
+			<ModalFooter>
+				<Button color="secondary" outline onClick={closeModal}>
+					Cancel
+				</Button>{" "}
+				<ButtonWrapper spinnerOnClick onClick={submit} >
+					Save
+				</ButtonWrapper>
+			</ModalFooter>
+		</Modal>
+		<Card>
+			<CardHeader>
+				<CardTitle tag="h5" className="mb-0">{props.cardTitle ?? "Report Table"}</CardTitle>
+			</CardHeader>
+			<CardBody>
+				<div style={{width: "900px"}} >
+					<SimpleReport 
+						keyField={props.primaryKey}
+						data={data}
+						columns={props.columns}
+						bootstrap4
+						bordered={false}
+						sizePerPage={12}
+						sizePerPageList={[12, 25, 50, 1000]}
+					/>
+					<Button className="mr-1 mb-1" outline onClick={() => openForEdit(none) }>Add Row</Button>
+				</div>
+			</CardBody>
+		</Card>
+	</React.Fragment>;
 }

--- a/src/pages/accessControl.ts
+++ b/src/pages/accessControl.ts
@@ -3,19 +3,23 @@ import assertNever from "@util/assertNever";
 import { PageName } from "./pageNames";
 
 export function canAccessPage(pageName: PageName): boolean {
-	switch (pageName){
-	case PageName.HOME:
-	case PageName.JP_CLASSES:
-	case PageName.STAGGERED_ORDER:
-		return true;
-	case PageName.USERS:
-	case PageName.USERS_EDIT:
-	case PageName.USERS_NEW:
-	case PageName.MANAGE_INSTRUCTORS:
-		const userType = asc.state.login.permissions.getOrElse(null).userType ;
-		return userType == "M"|| userType == "A"
-	default:
-		assertNever(pageName);
-		return false
-	}
+    switch (pageName) {
+        case PageName.HOME:
+        case PageName.JP_CLASSES:
+        case PageName.STAGGERED_ORDER:
+            return true;
+
+        case PageName.USERS:
+        case PageName.USERS_EDIT:
+        case PageName.USERS_NEW:
+        case PageName.MANAGE_INSTRUCTORS:
+        case PageName.MANAGE_TAGS:
+            const userType =
+                asc.state.login.permissions.getOrElse(null).userType;
+            return userType == "M" || userType == "A";
+
+        default:
+            assertNever(pageName);
+            return false;
+    }
 }

--- a/src/pages/accessControl.ts
+++ b/src/pages/accessControl.ts
@@ -3,20 +3,20 @@ import assertNever from "@util/assertNever";
 import { PageName } from "./pageNames";
 
 export function canAccessPage(pageName: PageName): boolean {
-	switch (pageName){
-	case PageName.HOME:
-	case PageName.JP_CLASSES:
-	case PageName.STAGGERED_ORDER:
-		return true;
-	case PageName.USERS:
-	case PageName.USERS_EDIT:
-	case PageName.USERS_NEW:
-	case PageName.MANAGE_INSTRUCTORS:
-    case PageName.MANAGE_TAGS:
-		const userType = asc.state.login.permissions.getOrElse(null).userType ;
-		return userType == "M"|| userType == "A"
-	default:
-		assertNever(pageName);
-		return false
+	switch (pageName) {
+		case PageName.HOME:
+		case PageName.JP_CLASSES:
+		case PageName.STAGGERED_ORDER:
+			return true;
+		case PageName.USERS:
+		case PageName.USERS_EDIT:
+		case PageName.USERS_NEW:
+		case PageName.MANAGE_INSTRUCTORS:
+		case PageName.MANAGE_TAGS:
+			const userType = asc.state.login.permissions.getOrElse(null).userType;
+			return userType == "M" || userType == "A";
+		default:
+			assertNever(pageName);
+			return false;
 	}
 }

--- a/src/pages/accessControl.ts
+++ b/src/pages/accessControl.ts
@@ -3,23 +3,20 @@ import assertNever from "@util/assertNever";
 import { PageName } from "./pageNames";
 
 export function canAccessPage(pageName: PageName): boolean {
-    switch (pageName) {
-        case PageName.HOME:
-        case PageName.JP_CLASSES:
-        case PageName.STAGGERED_ORDER:
-            return true;
-
-        case PageName.USERS:
-        case PageName.USERS_EDIT:
-        case PageName.USERS_NEW:
-        case PageName.MANAGE_INSTRUCTORS:
-        case PageName.MANAGE_TAGS:
-            const userType =
-                asc.state.login.permissions.getOrElse(null).userType;
-            return userType == "M" || userType == "A";
-
-        default:
-            assertNever(pageName);
-            return false;
-    }
+	switch (pageName){
+	case PageName.HOME:
+	case PageName.JP_CLASSES:
+	case PageName.STAGGERED_ORDER:
+		return true;
+	case PageName.USERS:
+	case PageName.USERS_EDIT:
+	case PageName.USERS_NEW:
+	case PageName.MANAGE_INSTRUCTORS:
+    case PageName.MANAGE_TAGS:
+		const userType = asc.state.login.permissions.getOrElse(null).userType ;
+		return userType == "M"|| userType == "A"
+	default:
+		assertNever(pageName);
+		return false
+	}
 }

--- a/src/pages/admin/ManageTagsPage.tsx
+++ b/src/pages/admin/ManageTagsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as t from "io-ts";
-import { Form, FormGroup, Label, Col, Input } from "reactstrap";
+import { FormGroup, Label, Col, Input } from "reactstrap";
 import { ColumnDescription } from "react-bootstrap-table-next";
 
 // Table building utilities
@@ -17,77 +17,68 @@ import ReportWithModalForm from "@components/ReportWithModalForm";
 type Tag = t.TypeOf<typeof tagValidator>;
 
 export default function ManageTagsPage(props: { tags: Tag[] }) {
-    // Block the default "enter" event on inputs which otherwise
-    // results in a page reload
-    function blockDefaultEnter(e: React.KeyboardEvent) {
-        if (e.key === "Enter") e.preventDefault();
-    }
+	// Define table columns
+	const columns: ColumnDescription[] = [
+		{
+			dataField: "edit",
+			text: "",
+			...tableColWidth(50),
+		},
+		{
+			dataField: "TAG_ID",
+			text: "ID",
+			sort: true,
+			...tableColWidth(80),
+		},
+		{
+			dataField: "TAG_NAME",
+			text: "Tag Name",
+			sort: true,
+		},
+	];
 
-    // Define table columns
-    const columns: ColumnDescription[] = [
-        {
-            dataField: "edit",
-            text: "",
-            ...tableColWidth(50),
-        },
-        {
-            dataField: "TAG_ID",
-            text: "ID",
-            sort: true,
-            ...tableColWidth(80),
-        },
-        {
-            dataField: "TAG_NAME",
-            text: "Tag Name",
-            sort: true,
-        },
-    ];
+	// Define edit/add form
+	const formComponents = (
+		rowForEdit: OptionifiedProps<Tag>,
+		updateState: (id: string, value: string) => void
+	) => (
+		<React.Fragment>
+			<FormGroup row>
+				<Label sm={2} className="text-sm-right">
+					ID
+				</Label>
+				<Col sm={10}>
+					<div style={{ textAlign: "left", padding: "5px 14px" }}>
+						{rowForEdit.TAG_ID.map(String).getOrElse("(none)")}
+					</div>
+				</Col>
+			</FormGroup>
+			<FormGroup row>
+				<Label sm={2} className="text-sm-right">
+					Tag Name
+				</Label>
+				<Col sm={10}>
+					<Input
+						type="text"
+						name="tagName"
+						placeholder="Tag Name"
+						value={rowForEdit.TAG_NAME.getOrElse("")}
+						onChange={(event) => updateState("TAG_NAME", event.target.value)}
+					/>
+				</Col>
+			</FormGroup>
+		</React.Fragment>
+	);
 
-    // Define edit/add form
-    const form = (
-        rowForEdit: OptionifiedProps<Tag>,
-        updateState: (id: string, value: string) => void
-    ) => (
-        <Form>
-            <FormGroup row>
-                <Label sm={2} className="text-sm-right">
-                    ID
-                </Label>
-                <Col sm={10}>
-                    <div style={{ textAlign: "left", padding: "5px 14px" }}>
-                        {rowForEdit.TAG_ID.map(String).getOrElse("(none)")}
-                    </div>
-                </Col>
-            </FormGroup>
-            <FormGroup row>
-                <Label sm={2} className="text-sm-right">
-                    Tag Name
-                </Label>
-                <Col sm={10}>
-                    <Input
-                        type="text"
-                        name="tagName"
-                        placeholder="Tag Name"
-                        value={rowForEdit.TAG_NAME.getOrElse("")}
-                        onKeyDown={blockDefaultEnter}
-                        onChange={(event) =>
-                            updateState("TAG_NAME", event.target.value)
-                        }
-                    />
-                </Col>
-            </FormGroup>
-        </Form>
-    );
-
-    return (
-        <ReportWithModalForm
-            rowValidator={tagValidator}
-            rows={props.tags}
-            primaryKey="TAG_ID"
-            columns={columns}
-            form={form}
-            submitRow={putTag}
-            cardTitle="Tags"
-        />
-    );
+	return (
+		<ReportWithModalForm
+			rowValidator={tagValidator}
+			rows={props.tags}
+			primaryKey="TAG_ID"
+			columns={columns}
+			formComponents={formComponents}
+			submitRow={putTag}
+			cardTitle="Tags"
+		/>
+	);
 }

--- a/src/pages/admin/ManageTagsPage.tsx
+++ b/src/pages/admin/ManageTagsPage.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import * as t from "io-ts";
+import { Form, FormGroup, Label, Col, Input } from "reactstrap";
+import { ColumnDescription } from "react-bootstrap-table-next";
+
+// Table building utilities
+import { tableColWidth } from "@util/tableUtil";
+import { OptionifiedProps } from "@util/OptionifyObjectProps";
+
+// Validator and putter for the data type of this page
+import { tagValidator } from "@async/rest/tags";
+import { putWrapper as putTag } from "@async/rest/tags";
+
+// The common display structure which is a table editable via modal
+import ReportWithModalForm from "@components/ReportWithModalForm";
+
+type Tag = t.TypeOf<typeof tagValidator>;
+
+export default function ManageTagsPage(props: { tags: Tag[] }) {
+    // Block the default "enter" event on inputs which otherwise
+    // results in a page reload
+    function blockDefaultEnter(e: React.KeyboardEvent) {
+        if (e.key === "Enter") e.preventDefault();
+    }
+
+    // Define table columns
+    const columns: ColumnDescription[] = [
+        {
+            dataField: "edit",
+            text: "",
+            ...tableColWidth(50),
+        },
+        {
+            dataField: "TAG_ID",
+            text: "ID",
+            sort: true,
+            ...tableColWidth(80),
+        },
+        {
+            dataField: "TAG_NAME",
+            text: "Tag Name",
+            sort: true,
+        },
+    ];
+
+    // Define edit/add form
+    const form = (
+        rowForEdit: OptionifiedProps<Tag>,
+        updateState: (id: string, value: string) => void
+    ) => (
+        <Form>
+            <FormGroup row>
+                <Label sm={2} className="text-sm-right">
+                    ID
+                </Label>
+                <Col sm={10}>
+                    <div style={{ textAlign: "left", padding: "5px 14px" }}>
+                        {rowForEdit.TAG_ID.map(String).getOrElse("(none)")}
+                    </div>
+                </Col>
+            </FormGroup>
+            <FormGroup row>
+                <Label sm={2} className="text-sm-right">
+                    Tag Name
+                </Label>
+                <Col sm={10}>
+                    <Input
+                        type="text"
+                        name="tagName"
+                        placeholder="Tag Name"
+                        value={rowForEdit.TAG_NAME.getOrElse("")}
+                        onKeyDown={blockDefaultEnter}
+                        onChange={(event) =>
+                            updateState("TAG_NAME", event.target.value)
+                        }
+                    />
+                </Col>
+            </FormGroup>
+        </Form>
+    );
+
+    return (
+        <ReportWithModalForm
+            rowValidator={tagValidator}
+            rows={props.tags}
+            primaryKey="TAG_ID"
+            columns={columns}
+            form={form}
+            submitRow={putTag}
+            cardTitle="Tags"
+        />
+    );
+}

--- a/src/pages/pageNames.ts
+++ b/src/pages/pageNames.ts
@@ -1,10 +1,10 @@
 export enum PageName {
-    HOME = "home",
-    JP_CLASSES = "jpClasses",
-    USERS = "users",
-    USERS_EDIT = "users_edit",
-    USERS_NEW = "users_new",
-    STAGGERED_ORDER = "staggered_order",
-    MANAGE_INSTRUCTORS = "manage_instructors",
-    MANAGE_TAGS = "manage_tags",
+	HOME="home",
+	JP_CLASSES="jpClasses",
+	USERS="users",
+	USERS_EDIT="users_edit",
+	USERS_NEW="users_new",
+	STAGGERED_ORDER="staggered_order",
+	MANAGE_INSTRUCTORS="manage_instructors",
+	MANAGE_TAGS = "manage_tags",
 }

--- a/src/pages/pageNames.ts
+++ b/src/pages/pageNames.ts
@@ -1,9 +1,10 @@
 export enum PageName {
-	HOME="home",
-	JP_CLASSES="jpClasses",
-	USERS="users",
-	USERS_EDIT="users_edit",
-	USERS_NEW="users_new",
-	STAGGERED_ORDER="staggered_order",
-	MANAGE_INSTRUCTORS="manage_instructors",
+    HOME = "home",
+    JP_CLASSES = "jpClasses",
+    USERS = "users",
+    USERS_EDIT = "users_edit",
+    USERS_NEW = "users_new",
+    STAGGERED_ORDER = "staggered_order",
+    MANAGE_INSTRUCTORS = "manage_instructors",
+    MANAGE_TAGS = "manage_tags",
 }


### PR DESCRIPTION
### Description
Added the "Manage Tags" page to the Admin section, utilizing the REST endpoint at `/api/rest/tags`. This page allows for simple creation, reading, and updating of tags.

**JIRA Tracker:**  [STAFF-12](https://community-boating.atlassian.net/browse/STAFFWEB-12?atlOrigin=eyJpIjoiNTA3NmVjODI0NGYwNDFmODk5YWNiM2E0OTFjZDQ4NDgiLCJwIjoiaiJ9)

### Type of Request
- [x] New feature
- [ ] Bug fix
- [ ] Other: 

### New Features
* Adds new page: Manage Tags at `/admin/tags`

### Other Changes
* Added `cardTitle` prop to the `ReportWithModalForm` component, configuring the title on the form table's parent card
* Configured `postcss:^8.3.6` as a dev dependency: this is required to run the dev environment