### PR TITLE
Create Manage High Schools Page

### DIFF
--- a/src/app/SidebarCategories.ts
+++ b/src/app/SidebarCategories.ts
@@ -9,6 +9,7 @@ import { jpClassesPageRoute } from "@routes/jp-classes";
 import { staggeredOrderRoute } from "@routes/staggered-order";
 import { manageClassInstructorsPageRoute } from "@routes/admin/class-instructors";
 import { manageTagsPageRoute } from "@routes/admin/tags";
+import { manageHighSchoolsRoute } from "@routes/admin/high-schools";
 
 export type SideBarCategory = {
 	path: string,
@@ -35,6 +36,7 @@ const admin: SideBarCategory = {
 		usersPageRoute,
 		manageClassInstructorsPageRoute,
 		manageTagsPageRoute,
+		manageHighSchoolsRoute
 	],
 	unrenderedChildren: [
 		usersNewPageRoute,

--- a/src/app/routes/admin/high-schools.tsx
+++ b/src/app/routes/admin/high-schools.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import * as t from "io-ts";
+
+import RouteWrapper from "@core/RouteWrapper";
+import PageWrapper from "@core/PageWrapper";
+import Loader from "@components/Loader";
+
+import { adminBasePath } from "./_base";
+import { PageName } from "pages/pageNames";
+import ManageHighSchoolsPage from "pages/admin/ManageHighSchoolsPage";
+import { validator, getWrapper } from "@async/rest/high-schools";
+
+export const manageHighSchools = adminBasePath.appendPathSegment("high-schools");
+
+export const manageHighSchoolsRoute = new RouteWrapper(
+	{
+		requiresAuth: true,
+		exact: true,
+		pathWrapper: manageHighSchools,
+		sidebarTitle: "Manage High Schools",
+		pageName: PageName.MANAGE_HIGH_SCHOOLS,
+		requireSudo: true,
+	},
+	(history) => (
+		<PageWrapper
+			key="manage high schools"
+			history={history}
+			component={(_urlProps: {}, async: t.TypeOf<typeof validator>) => (
+				<ManageHighSchoolsPage highSchools={async} />
+			)}
+			urlProps={{}}
+			getAsyncProps={() => {
+				return getWrapper.send(null);
+			}}
+			shadowComponent={<Loader />}
+		/>
+	)
+);

--- a/src/async/rest/high-schools.ts
+++ b/src/async/rest/high-schools.ts
@@ -19,8 +19,7 @@ export const getWrapper = new APIWrapper({
 });
 
 const resultValidator = t.type({
-	SCHOOL_ID: t.number,
-	ACTIVE: t.boolean
+	SCHOOL_ID: t.number
 });
 
 export const putWrapper = new APIWrapper<

--- a/src/async/rest/high-schools.ts
+++ b/src/async/rest/high-schools.ts
@@ -1,0 +1,34 @@
+import * as t from "io-ts";
+import APIWrapper from "../../core/APIWrapper";
+import { HttpMethod } from "../../core/HttpMethod";
+
+export const highSchoolValidator = t.type({
+	SCHOOL_ID: t.number,
+	SCHOOL_NAME: t.string,
+	ACTIVE: t.boolean
+});
+
+export const validator = t.array(highSchoolValidator);
+
+const path = "/rest/high-school";
+
+export const getWrapper = new APIWrapper({
+	path,
+	type: HttpMethod.GET,
+	resultValidator: validator,
+});
+
+const resultValidator = t.type({
+	SCHOOL_ID: t.number,
+	ACTIVE: t.boolean
+});
+
+export const putWrapper = new APIWrapper<
+	typeof resultValidator,
+	t.TypeOf<typeof highSchoolValidator>,
+	null
+>({
+	path,
+	type: HttpMethod.POST,
+	resultValidator,
+});

--- a/src/components/ReportWithModalForm.tsx
+++ b/src/components/ReportWithModalForm.tsx
@@ -18,7 +18,7 @@ export default function ReportWithModalForm<T extends t.TypeC<any>, U extends ob
 	rows: U[],
 	primaryKey: string & keyof U,
 	columns: ColumnDescription[],
-	formComponents: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string) => void) => JSX.Element
+	formComponents: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string | boolean) => void) => JSX.Element
 	submitRow: APIWrapper<any, U, any>
 	cardTitle?: string;
 }) {
@@ -91,8 +91,6 @@ export default function ReportWithModalForm<T extends t.TypeC<any>, U extends ob
 		}}><EditIcon color="#777" size="1.4em" /></a>,
 	}));
 
-	console.log(formData)
-
 	return <React.Fragment>
 		<Modal
 			isOpen={modalIsOpen}
@@ -125,7 +123,7 @@ export default function ReportWithModalForm<T extends t.TypeC<any>, U extends ob
 				<CardTitle tag="h5" className="mb-0">{props.cardTitle ?? "Report Table"}</CardTitle>
 			</CardHeader>
 			<CardBody>
-				<div style={{width: "900px"}} >
+				<div>
 					<SimpleReport 
 						keyField={props.primaryKey}
 						data={data}

--- a/src/pages/accessControl.ts
+++ b/src/pages/accessControl.ts
@@ -13,6 +13,7 @@ export function canAccessPage(pageName: PageName): boolean {
 		case PageName.USERS_NEW:
 		case PageName.MANAGE_INSTRUCTORS:
 		case PageName.MANAGE_TAGS:
+		case PageName.MANAGE_HIGH_SCHOOLS:
 			const userType = asc.state.login.permissions.getOrElse(null).userType;
 			return userType == "M" || userType == "A";
 		default:

--- a/src/pages/admin/ManageHighSchoolsPage.tsx
+++ b/src/pages/admin/ManageHighSchoolsPage.tsx
@@ -1,0 +1,113 @@
+import * as React from "react";
+import * as t from "io-ts";
+import { FormGroup, Label, Col, Input, CustomInput } from "reactstrap";
+import { ColumnDescription } from "react-bootstrap-table-next";
+import { Check as CheckIcon } from "react-feather";
+
+// Table building utilities
+import { tableColWidth } from "@util/tableUtil";
+import { OptionifiedProps } from "@util/OptionifyObjectProps";
+// import {formUpdateState} from '@util/form-update-state';
+
+// Validator and putter for the data type of this page
+import { highSchoolValidator } from "@async/rest/high-schools";
+import { putWrapper as putHighSchool } from "@async/rest/high-schools";
+
+// The common display structure which is a table editable via modal
+import ReportWithModalForm from "@components/ReportWithModalForm";
+// import FormElementCheckbox from "@components/form/FormElementCheckbox";
+
+type HighSchool = t.TypeOf<typeof highSchoolValidator>;
+// class FormCheckbox extends FormElementCheckbox<FormData> {}
+
+export default function ManageHighSchoolsPage(props: {
+	highSchools: HighSchool[];
+}) {
+	// Define table columns
+	const columns: ColumnDescription[] = [
+		{
+			dataField: "edit",
+			text: "",
+			...tableColWidth(50),
+		},
+		{
+			dataField: "SCHOOL_ID",
+			text: "ID",
+			sort: true,
+			...tableColWidth(80),
+		},
+		{
+			dataField: "SCHOOL_NAME",
+			text: "School Name",
+			sort: true,
+		},
+		{
+			dataField: "ACTIVE",
+			text: "Active",
+			sort: true,
+			formatter: (value: boolean, row) => {
+				return value ? <CheckIcon color="#777" size="1.4em" /> : null;
+			},
+			...tableColWidth(100),
+		},
+	];
+
+	// Define edit/add form
+	const formComponents = (
+		rowForEdit: OptionifiedProps<HighSchool>,
+		updateState: (id: string, value: string | boolean) => void
+	) => (
+		<React.Fragment>
+			<FormGroup row>
+				<Label sm={3} className="text-sm-right">
+					ID
+				</Label>
+				<Col sm={9}>
+					<div style={{ padding: "5px" }} className="text-left">
+						{rowForEdit.SCHOOL_ID.map(String).getOrElse("(none)")}
+					</div>
+				</Col>
+			</FormGroup>
+			<FormGroup row className="align-items-center">
+				<Label sm={3} className="text-sm-right">
+					School Name
+				</Label>
+				<Col sm={9}>
+					<Input
+						type="text"
+						name="highSchoolName"
+						placeholder="School Name"
+						value={rowForEdit.SCHOOL_NAME.getOrElse("")}
+						onChange={(event) => updateState("SCHOOL_NAME", event.target.value)}
+					/>
+				</Col>
+			</FormGroup>
+			<FormGroup row className="align-items-center">
+				<Label sm={3} className="text-sm-right">
+					Active
+				</Label>
+				<Col sm={9}>
+					<CustomInput
+						type="checkbox"
+						id="highSchoolActive"
+						checked={rowForEdit.ACTIVE.getOrElse(false)}
+						className="text-left"
+						onChange={(event) => updateState("ACTIVE", event.target.checked)}
+					/>
+				</Col>
+			</FormGroup>
+		</React.Fragment>
+	);
+
+	return (
+		<ReportWithModalForm
+			rowValidator={highSchoolValidator}
+			rows={props.highSchools}
+			primaryKey="SCHOOL_ID"
+			columns={columns}
+			formComponents={formComponents}
+			submitRow={putHighSchool}
+			cardTitle="Tags"
+		/>
+	);
+}

--- a/src/pages/admin/ManageHighSchoolsPage.tsx
+++ b/src/pages/admin/ManageHighSchoolsPage.tsx
@@ -6,8 +6,7 @@ import { Check as CheckIcon } from "react-feather";
 
 // Table building utilities
 import { tableColWidth } from "@util/tableUtil";
-import { OptionifiedProps } from "@util/OptionifyObjectProps";
-// import {formUpdateState} from '@util/form-update-state';
+import { StringifiedProps } from "@util/StringifyObjectProps";
 
 // Validator and putter for the data type of this page
 import { highSchoolValidator } from "@async/rest/high-schools";
@@ -15,7 +14,6 @@ import { putWrapper as putHighSchool } from "@async/rest/high-schools";
 
 // The common display structure which is a table editable via modal
 import ReportWithModalForm from "@components/ReportWithModalForm";
-// import FormElementCheckbox from "@components/form/FormElementCheckbox";
 
 type HighSchool = t.TypeOf<typeof highSchoolValidator>;
 // class FormCheckbox extends FormElementCheckbox<FormData> {}
@@ -45,16 +43,13 @@ export default function ManageHighSchoolsPage(props: {
 			dataField: "ACTIVE",
 			text: "Active",
 			sort: true,
-			formatter: (value: boolean, row) => {
-				return value ? <CheckIcon color="#777" size="1.4em" /> : null;
-			},
 			...tableColWidth(100),
 		},
 	];
 
 	// Define edit/add form
 	const formComponents = (
-		rowForEdit: OptionifiedProps<HighSchool>,
+		rowForEdit: StringifiedProps<HighSchool>,
 		updateState: (id: string, value: string | boolean) => void
 	) => (
 		<React.Fragment>
@@ -64,7 +59,7 @@ export default function ManageHighSchoolsPage(props: {
 				</Label>
 				<Col sm={9}>
 					<div style={{ padding: "5px" }} className="text-left">
-						{rowForEdit.SCHOOL_ID.map(String).getOrElse("(none)")}
+						{rowForEdit.SCHOOL_ID || "(none)"}
 					</div>
 				</Col>
 			</FormGroup>
@@ -77,7 +72,7 @@ export default function ManageHighSchoolsPage(props: {
 						type="text"
 						name="highSchoolName"
 						placeholder="School Name"
-						value={rowForEdit.SCHOOL_NAME.getOrElse("")}
+						value={rowForEdit.SCHOOL_NAME}
 						onChange={(event) => updateState("SCHOOL_NAME", event.target.value)}
 					/>
 				</Col>
@@ -90,7 +85,7 @@ export default function ManageHighSchoolsPage(props: {
 					<CustomInput
 						type="checkbox"
 						id="highSchoolActive"
-						checked={rowForEdit.ACTIVE.getOrElse(false)}
+						checked={rowForEdit.ACTIVE == "Y"}
 						className="text-left"
 						onChange={(event) => updateState("ACTIVE", event.target.checked)}
 					/>
@@ -103,6 +98,10 @@ export default function ManageHighSchoolsPage(props: {
 		<ReportWithModalForm
 			rowValidator={highSchoolValidator}
 			rows={props.highSchools}
+			formatRowForDisplay={(hs) => ({
+				...hs,
+				ACTIVE: hs.ACTIVE ? <CheckIcon color="#777" size="1.4em" /> : null,
+			})}
 			primaryKey="SCHOOL_ID"
 			columns={columns}
 			formComponents={formComponents}

--- a/src/pages/pageNames.ts
+++ b/src/pages/pageNames.ts
@@ -7,4 +7,5 @@ export enum PageName {
 	STAGGERED_ORDER="staggered_order",
 	MANAGE_INSTRUCTORS="manage_instructors",
 	MANAGE_TAGS = "manage_tags",
+	MANAGE_HIGH_SCHOOLS = "manage_high_schools",
 }


### PR DESCRIPTION
### Description
Added the "Manage High Schools" page to the Admin section, utilizing the REST endpoint at `/api/rest/high-school`. This page allows for simple creation, reading, and updating of high schools.

**JIRA Tracker:**  [STAFF-13](https://community-boating.atlassian.net/browse/STAFFWEB-13?atlOrigin=eyJpIjoiYzA2YWNmNmM3ZTIyNGRjZmEwYTI3MzYzNTRjOWMzZjYiLCJwIjoiaiJ9)

### Type of Request
- [x] New feature
- [ ] Bug fix
- [ ] Other: 

### New Features
* Adds new page: Manage High Schools at `/admin/high-schools`

### Other Changes
* Change `value: string | boolean` to `value: string | boolean` in the `ReportWithModalForm` component, allowing for state updates to form fields that have booleans in addition to strings.
* Removed the `900px` fixed width on the `ReportWithModalForm` component, letting the table be responsive to its parent. (I get that this is an opinionated change, so lemme know if you want the 900px back)