### PR TITLE
Create Manage Class Locations Page

### DIFF
--- a/src/app/SidebarCategories.ts
+++ b/src/app/SidebarCategories.ts
@@ -9,6 +9,7 @@ import { jpClassesPageRoute } from "@routes/jp-classes";
 import { staggeredOrderRoute } from "@routes/staggered-order";
 import { manageClassInstructorsPageRoute } from "@routes/admin/class-instructors";
 import { manageTagsPageRoute } from "@routes/admin/tags";
+import { manageClassLocationsPageRoute } from "@routes/admin/class-locations";
 
 export type SideBarCategory = {
 	path: string,
@@ -35,6 +36,7 @@ const admin: SideBarCategory = {
 		usersPageRoute,
 		manageClassInstructorsPageRoute,
 		manageTagsPageRoute,
+		manageClassLocationsPageRoute,
 	],
 	unrenderedChildren: [
 		usersNewPageRoute,

--- a/src/app/routes/admin/class-locations.tsx
+++ b/src/app/routes/admin/class-locations.tsx
@@ -30,7 +30,7 @@ export const manageClassLocationsPageRoute = new RouteWrapper(
 			)}
 			urlProps={{}}
 			getAsyncProps={() => {
-				return getWrapper();
+				return getWrapper.send(null);
 			}}
 			shadowComponent={<Loader />}
 		/>

--- a/src/app/routes/admin/class-locations.tsx
+++ b/src/app/routes/admin/class-locations.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import * as t from "io-ts";
+
+import RouteWrapper from "@core/RouteWrapper";
+import PageWrapper from "@core/PageWrapper";
+import Loader from "@components/Loader";
+
+import { adminBasePath } from "./_base";
+import { PageName } from "pages/pageNames";
+import ManageClassLocationsPage from "pages/admin/ManageClassLocationsPage";
+import { validator, getWrapper } from "@async/rest/class-locations";
+
+export const manageClassLocationsPath = adminBasePath.appendPathSegment("class-locations");
+
+export const manageClassLocationsPageRoute = new RouteWrapper(
+	{
+		requiresAuth: true,
+		exact: true,
+		pathWrapper: manageClassLocationsPath,
+		sidebarTitle: "Manage Class Locations",
+		pageName: PageName.MANAGE_CLASS_LOCATIONS,
+		requireSudo: true,
+	},
+	(history) => (
+		<PageWrapper
+			key="manage class locations"
+			history={history}
+			component={(_urlProps: {}, async: t.TypeOf<typeof validator>) => (
+				<ManageClassLocationsPage locations={async} />
+			)}
+			urlProps={{}}
+			getAsyncProps={() => {
+				return getWrapper();
+			}}
+			shadowComponent={<Loader />}
+		/>
+	)
+);

--- a/src/async/rest/class-locations.ts
+++ b/src/async/rest/class-locations.ts
@@ -1,4 +1,3 @@
-import { ApiResult } from "@core/APIWrapperTypes";
 import * as t from "io-ts";
 import APIWrapper from "../../core/APIWrapper";
 import { HttpMethod } from "../../core/HttpMethod";
@@ -6,34 +5,22 @@ import { HttpMethod } from "../../core/HttpMethod";
 export const classLocationValidator = t.type({
 	LOCATION_ID: t.number,
 	LOCATION_NAME: t.string,
+	ACTIVE: t.boolean,
 });
 
 export const validator = t.array(classLocationValidator);
 
 const path = "/rest/class-location";
 
-// export const getWrapper = new APIWrapper({
-// 	path,
-// 	type: HttpMethod.GET,
-// 	resultValidator: validator,
-// });
-
-export const getWrapper = (): Promise<
-	ApiResult<t.TypeOf<typeof validator>>
-> => {
-	return Promise.resolve({
-		type: "Success",
-		success: [
-			{
-				LOCATION_ID: 984,
-				LOCATION_NAME: "Just an example",
-			},
-		],
-	} as ApiResult<t.TypeOf<typeof validator>>);
-};
+export const getWrapper = new APIWrapper({
+	path,
+	type: HttpMethod.GET,
+	resultValidator: validator,
+});
 
 const resultValidator = t.type({
 	LOCATION_ID: t.number,
+	LOCATION_NAME: t.string,
 });
 
 export const putWrapper = new APIWrapper<

--- a/src/async/rest/class-locations.ts
+++ b/src/async/rest/class-locations.ts
@@ -20,7 +20,6 @@ export const getWrapper = new APIWrapper({
 
 const resultValidator = t.type({
 	LOCATION_ID: t.number,
-	LOCATION_NAME: t.string,
 });
 
 export const putWrapper = new APIWrapper<

--- a/src/async/rest/class-locations.ts
+++ b/src/async/rest/class-locations.ts
@@ -1,0 +1,47 @@
+import { ApiResult } from "@core/APIWrapperTypes";
+import * as t from "io-ts";
+import APIWrapper from "../../core/APIWrapper";
+import { HttpMethod } from "../../core/HttpMethod";
+
+export const classLocationValidator = t.type({
+	LOCATION_ID: t.number,
+	LOCATION_NAME: t.string,
+});
+
+export const validator = t.array(classLocationValidator);
+
+const path = "/rest/class-location";
+
+// export const getWrapper = new APIWrapper({
+// 	path,
+// 	type: HttpMethod.GET,
+// 	resultValidator: validator,
+// });
+
+export const getWrapper = (): Promise<
+	ApiResult<t.TypeOf<typeof validator>>
+> => {
+	return Promise.resolve({
+		type: "Success",
+		success: [
+			{
+				LOCATION_ID: 984,
+				LOCATION_NAME: "Just an example",
+			},
+		],
+	} as ApiResult<t.TypeOf<typeof validator>>);
+};
+
+const resultValidator = t.type({
+	LOCATION_ID: t.number,
+});
+
+export const putWrapper = new APIWrapper<
+	typeof resultValidator,
+	t.TypeOf<typeof classLocationValidator>,
+	null
+>({
+	path,
+	type: HttpMethod.POST,
+	resultValidator,
+});

--- a/src/components/ReportWithModalForm.tsx
+++ b/src/components/ReportWithModalForm.tsx
@@ -18,7 +18,7 @@ export default function ReportWithModalForm<T extends t.TypeC<any>, U extends ob
 	rows: U[],
 	primaryKey: string & keyof U,
 	columns: ColumnDescription[],
-	formComponents: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string) => void) => JSX.Element
+	formComponents: (rowForEdit: OptionifiedProps<U>, updateState: (id: string, value: string | boolean) => void) => JSX.Element
 	submitRow: APIWrapper<any, U, any>
 	cardTitle?: string;
 }) {
@@ -125,7 +125,7 @@ export default function ReportWithModalForm<T extends t.TypeC<any>, U extends ob
 				<CardTitle tag="h5" className="mb-0">{props.cardTitle ?? "Report Table"}</CardTitle>
 			</CardHeader>
 			<CardBody>
-				<div style={{width: "900px"}} >
+				<div>
 					<SimpleReport 
 						keyField={props.primaryKey}
 						data={data}

--- a/src/pages/accessControl.ts
+++ b/src/pages/accessControl.ts
@@ -13,6 +13,7 @@ export function canAccessPage(pageName: PageName): boolean {
 		case PageName.USERS_NEW:
 		case PageName.MANAGE_INSTRUCTORS:
 		case PageName.MANAGE_TAGS:
+		case PageName.MANAGE_CLASS_LOCATIONS:
 			const userType = asc.state.login.permissions.getOrElse(null).userType;
 			return userType == "M" || userType == "A";
 		default:

--- a/src/pages/admin/ManageClassLocationsPage.tsx
+++ b/src/pages/admin/ManageClassLocationsPage.tsx
@@ -89,7 +89,7 @@ export default function ManageClassLocationsPage(props: {
 				<Col sm={9}>
 					<CustomInput
 						type="checkbox"
-						id="highSchoolActive"
+						id="isActive"
 						checked={rowForEdit.ACTIVE.getOrElse(false)}
 						className="text-left"
 						onChange={(event) => updateState("ACTIVE", event.target.checked)}

--- a/src/pages/admin/ManageClassLocationsPage.tsx
+++ b/src/pages/admin/ManageClassLocationsPage.tsx
@@ -73,7 +73,7 @@ export default function ManageClassLocationsPage(props: {
 					<Input
 						type="text"
 						name="tagName"
-						placeholder="ClassLocation Name"
+						placeholder="Class Location Name"
 						value={rowForEdit.LOCATION_NAME.getOrElse("")}
 						onChange={(event) =>
 							updateState("LOCATION_NAME", event.target.value)

--- a/src/pages/admin/ManageClassLocationsPage.tsx
+++ b/src/pages/admin/ManageClassLocationsPage.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import * as t from "io-ts";
-import { FormGroup, Label, Col, Input } from "reactstrap";
+import { FormGroup, Label, Col, Input, CustomInput } from "reactstrap";
 import { ColumnDescription } from "react-bootstrap-table-next";
+import { Check as CheckIcon } from "react-feather";
 
 // Table building utilities
 import { tableColWidth } from "@util/tableUtil";
@@ -16,7 +17,9 @@ import ReportWithModalForm from "@components/ReportWithModalForm";
 
 type ClassLocation = t.TypeOf<typeof classLocationValidator>;
 
-export default function ManageClassLocationsPage(props: { locations: ClassLocation[] }) {
+export default function ManageClassLocationsPage(props: {
+	locations: ClassLocation[];
+}) {
 	// Define table columns
 	const columns: ColumnDescription[] = [
 		{
@@ -32,38 +35,64 @@ export default function ManageClassLocationsPage(props: { locations: ClassLocati
 		},
 		{
 			dataField: "LOCATION_NAME",
-			text: "ClassLocation Name",
+			text: "Name",
 			sort: true,
+		},
+		{
+			dataField: "ACTIVE",
+			text: "Active",
+			sort: true,
+			formatter: (value: boolean, _row) => {
+				return value ? <CheckIcon color="#777" size="1.4em" /> : null;
+			},
+			...tableColWidth(100),
 		},
 	];
 
 	// Define edit/add form
 	const formComponents = (
 		rowForEdit: OptionifiedProps<ClassLocation>,
-		updateState: (id: string, value: string) => void
+		updateState: (id: string, value: string | boolean) => void
 	) => (
 		<React.Fragment>
 			<FormGroup row>
-				<Label sm={2} className="text-sm-right">
+				<Label sm={3} className="text-sm-right">
 					ID
 				</Label>
-				<Col sm={10}>
-					<div style={{ textAlign: "left", padding: "5px 14px" }}>
+				<Col sm={9}>
+					<div style={{ padding: "5px" }} className="text-left">
 						{rowForEdit.LOCATION_ID.map(String).getOrElse("(none)")}
 					</div>
 				</Col>
 			</FormGroup>
 			<FormGroup row>
-				<Label sm={2} className="text-sm-right">
-					Class Location Name
+				<Label sm={3} className="text-sm-right">
+					Location Name
 				</Label>
-				<Col sm={10}>
+				<Col sm={9}>
 					<Input
 						type="text"
 						name="tagName"
 						placeholder="ClassLocation Name"
 						value={rowForEdit.LOCATION_NAME.getOrElse("")}
-						onChange={(event) => updateState("LOCATION_NAME", event.target.value)}
+						onChange={(event) =>
+							updateState("LOCATION_NAME", event.target.value)
+						}
+					/>
+				</Col>
+			</FormGroup>
+
+			<FormGroup row className="align-items-center">
+				<Label sm={3} className="text-sm-right">
+					Active
+				</Label>
+				<Col sm={9}>
+					<CustomInput
+						type="checkbox"
+						id="highSchoolActive"
+						checked={rowForEdit.ACTIVE.getOrElse(false)}
+						className="text-left"
+						onChange={(event) => updateState("ACTIVE", event.target.checked)}
 					/>
 				</Col>
 			</FormGroup>

--- a/src/pages/admin/ManageClassLocationsPage.tsx
+++ b/src/pages/admin/ManageClassLocationsPage.tsx
@@ -6,7 +6,7 @@ import { Check as CheckIcon } from "react-feather";
 
 // Table building utilities
 import { tableColWidth } from "@util/tableUtil";
-import { OptionifiedProps } from "@util/OptionifyObjectProps";
+import { StringifiedProps } from "@util/StringifyObjectProps";
 
 // Validator and putter for the data type of this page
 import { classLocationValidator } from "@async/rest/class-locations";
@@ -42,16 +42,13 @@ export default function ManageClassLocationsPage(props: {
 			dataField: "ACTIVE",
 			text: "Active",
 			sort: true,
-			formatter: (value: boolean, _row) => {
-				return value ? <CheckIcon color="#777" size="1.4em" /> : null;
-			},
 			...tableColWidth(100),
 		},
 	];
 
 	// Define edit/add form
 	const formComponents = (
-		rowForEdit: OptionifiedProps<ClassLocation>,
+		rowForEdit: StringifiedProps<ClassLocation>,
 		updateState: (id: string, value: string | boolean) => void
 	) => (
 		<React.Fragment>
@@ -61,7 +58,7 @@ export default function ManageClassLocationsPage(props: {
 				</Label>
 				<Col sm={9}>
 					<div style={{ padding: "5px" }} className="text-left">
-						{rowForEdit.LOCATION_ID.map(String).getOrElse("(none)")}
+						{rowForEdit.LOCATION_ID || "(none)"}
 					</div>
 				</Col>
 			</FormGroup>
@@ -74,7 +71,7 @@ export default function ManageClassLocationsPage(props: {
 						type="text"
 						name="tagName"
 						placeholder="Class Location Name"
-						value={rowForEdit.LOCATION_NAME.getOrElse("")}
+						value={rowForEdit.LOCATION_NAME}
 						onChange={(event) =>
 							updateState("LOCATION_NAME", event.target.value)
 						}
@@ -90,7 +87,7 @@ export default function ManageClassLocationsPage(props: {
 					<CustomInput
 						type="checkbox"
 						id="isActive"
-						checked={rowForEdit.ACTIVE.getOrElse(false)}
+						checked={rowForEdit.ACTIVE == "Y"}
 						className="text-left"
 						onChange={(event) => updateState("ACTIVE", event.target.checked)}
 					/>
@@ -103,6 +100,12 @@ export default function ManageClassLocationsPage(props: {
 		<ReportWithModalForm
 			rowValidator={classLocationValidator}
 			rows={props.locations}
+			formatRowForDisplay={(location) => ({
+				...location,
+				ACTIVE: location.ACTIVE ? (
+					<CheckIcon color="#777" size="1.4em" />
+				) : null,
+			})}
 			primaryKey="LOCATION_ID"
 			columns={columns}
 			formComponents={formComponents}

--- a/src/pages/admin/ManageClassLocationsPage.tsx
+++ b/src/pages/admin/ManageClassLocationsPage.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import * as t from "io-ts";
+import { FormGroup, Label, Col, Input } from "reactstrap";
+import { ColumnDescription } from "react-bootstrap-table-next";
+
+// Table building utilities
+import { tableColWidth } from "@util/tableUtil";
+import { OptionifiedProps } from "@util/OptionifyObjectProps";
+
+// Validator and putter for the data type of this page
+import { classLocationValidator } from "@async/rest/class-locations";
+import { putWrapper as putClassLocation } from "@async/rest/class-locations";
+
+// The common display structure which is a table editable via modal
+import ReportWithModalForm from "@components/ReportWithModalForm";
+
+type ClassLocation = t.TypeOf<typeof classLocationValidator>;
+
+export default function ManageClassLocationsPage(props: { locations: ClassLocation[] }) {
+	// Define table columns
+	const columns: ColumnDescription[] = [
+		{
+			dataField: "edit",
+			text: "",
+			...tableColWidth(50),
+		},
+		{
+			dataField: "LOCATION_ID",
+			text: "ID",
+			sort: true,
+			...tableColWidth(80),
+		},
+		{
+			dataField: "LOCATION_NAME",
+			text: "ClassLocation Name",
+			sort: true,
+		},
+	];
+
+	// Define edit/add form
+	const formComponents = (
+		rowForEdit: OptionifiedProps<ClassLocation>,
+		updateState: (id: string, value: string) => void
+	) => (
+		<React.Fragment>
+			<FormGroup row>
+				<Label sm={2} className="text-sm-right">
+					ID
+				</Label>
+				<Col sm={10}>
+					<div style={{ textAlign: "left", padding: "5px 14px" }}>
+						{rowForEdit.LOCATION_ID.map(String).getOrElse("(none)")}
+					</div>
+				</Col>
+			</FormGroup>
+			<FormGroup row>
+				<Label sm={2} className="text-sm-right">
+					Class Location Name
+				</Label>
+				<Col sm={10}>
+					<Input
+						type="text"
+						name="tagName"
+						placeholder="ClassLocation Name"
+						value={rowForEdit.LOCATION_NAME.getOrElse("")}
+						onChange={(event) => updateState("LOCATION_NAME", event.target.value)}
+					/>
+				</Col>
+			</FormGroup>
+		</React.Fragment>
+	);
+
+	return (
+		<ReportWithModalForm
+			rowValidator={classLocationValidator}
+			rows={props.locations}
+			primaryKey="LOCATION_ID"
+			columns={columns}
+			formComponents={formComponents}
+			submitRow={putClassLocation}
+			cardTitle="Class Locations"
+		/>
+	);
+}

--- a/src/pages/pageNames.ts
+++ b/src/pages/pageNames.ts
@@ -7,4 +7,5 @@ export enum PageName {
 	STAGGERED_ORDER="staggered_order",
 	MANAGE_INSTRUCTORS="manage_instructors",
 	MANAGE_TAGS = "manage_tags",
+	MANAGE_CLASS_LOCATIONS = "manage_class_locations",
 }


### PR DESCRIPTION
### Description
Added the "Manage Class Locations" page to the Admin section, utilizing the REST endpoint at `/api/rest/class-locations`. This page allows for simple creation, reading, and updating of high schools.

**JIRA Tracker:**  [STAFF-18](https://community-boating.atlassian.net/browse/STAFFWEB-18)

### Type of Request
- [x] New feature
- [ ] Bug fix
- [ ] Other: 

### New Features
* Adds new page: Manage Class Locations at `/admin/class-locations`

### Other Changes
* _None_