### PR TITLE
Removed pagination, added scrolling to dock report modals

### DIFF
--- a/src/components/table/TabularForm.tsx
+++ b/src/components/table/TabularForm.tsx
@@ -3,6 +3,7 @@ import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Input, Table } from 'reactstrap';
 import { ColumnDef, flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
+import * as PerfectScrollbarAll from "react-perfect-scrollbar";
 
 const EditableCell: (props: {
 	value: any,
@@ -116,13 +117,15 @@ export function TabularForm<T>(props: {
 		getCoreRowModel: getCoreRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
 		getSortedRowModel: getSortedRowModel(),
-		getPaginationRowModel: getPaginationRowModel(),
+		//getPaginationRowModel: getPaginationRowModel(),
 		enableColumnFilters: false,
 		autoResetAll: false,
 	});
 
 	return React.useMemo(() => {
 		const firstRow = table.getRowModel().rows[0]
+
+		const PerfectScrollbar: any = PerfectScrollbarAll;
 	
 		const addRowElement = (
 			blankRow == null

--- a/src/pages/dockhouse/dock-report/FullStaff.tsx
+++ b/src/pages/dockhouse/dock-report/FullStaff.tsx
@@ -91,7 +91,6 @@ export const StaffReport = (props: Props) => <StaffTable {...props} staff={props
 
 /////////////////////////////////////////////////////////////////////////////////
 
-
 const EditStaffTable = (props: {
 	staff: StaffEditable[],
 	setSubmitAction: (submit: SubmitAction) => void,

--- a/src/pages/dockhouse/dock-report/index.tsx
+++ b/src/pages/dockhouse/dock-report/index.tsx
@@ -23,6 +23,10 @@ export type WeatherRecord = t.TypeOf<typeof dockReportWeatherValidator>;
 
 export type SubmitAction = () => Promise<Partial<DockReportState>>
 
+const classesTest = [
+
+]
+
 export const DockReportPage = (props: {
 	dockReportInitState: DockReportState
 }) => {
@@ -99,6 +103,7 @@ export const DockReportPage = (props: {
 		<Modal
 			isOpen={modalContent != null}
 			// toggle={() => setModalContent(null)}
+			scrollable
 			style={{maxWidth: `${modalWidth}px`}}
 		>
 			<ModalHeader toggle={() => setModalContent(null)}>


### PR DESCRIPTION
Just a very small hotfix that disables the react-table pagination and just uses native html scrolling for the modal on the dock report page. Allows people to actually edit more than 10 or so classes if there happen to be that many in a day.